### PR TITLE
Simplify plumbing class creation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,19 @@ Changes
 1.7 (unreleased)
 ----------------
 
-- No changes yet.
+- Replace ``Bases`` wrapper with a ``set`` containing ``derived_members``
+  to avoid multiple base class iteration.
+  [rnix, 2022-02-13]
+
+- Only keep most recent instructions on ``Stacks`` when parsing behaviors.
+  [rnix, 2022-02-13]
+
+- Simplify ``Stacks`` object.
+  [rnix, 2022-02-13]
+
+- Apply stage 1 and stage 2 instructions in ``plumber.__new__`` instead of
+  applying stage 2 instructions in ``plumber.__init__``.
+  [rnix, 2022-02-13]
 
 
 1.6

--- a/DISCUSS.rst
+++ b/DISCUSS.rst
@@ -1,2 +1,0 @@
-Design choices and ongoing discussions
-======================================

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -2,7 +2,7 @@ License
 =======
 
 Copyright (c) 2011-2021, BlueDynamics Alliance, Austria, Germany, Switzerland
-Copyright (c) 2021, Node Contributors
+Copyright (c) 2021-2022, Node Contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/TODO.rst
+++ b/TODO.rst
@@ -2,14 +2,6 @@ TODO
 ----
 
 - [ ] traceback should show in which plumbing class we are, not something inside
-  the plumber. yafowil is doing it. jensens: would you be so kind.
-
-- [X] verify behaviour with pickling in tests within plumber.
-  (see ``node.ext.zodb`` -> no issues occurred)
-
-- [X] verify behaviour with ZODB persistence in tests within plumber.
-  (see ``node.ext.zodb`` -> no issues occurred)
-
-- [X] subclassing for plumbing behaviors.
+  the plumber.
 
 - [ ] mature plumbing of properties.

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-./$1/bin/coverage run -m plumber.tests.test_plumber
+./$1/bin/coverage run -m plumber.tests.__init__
 ./$1/bin/coverage report
 ./$1/bin/coverage html

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 if [ -x "$(which python)" ]; then
-    ./py2/bin/python -m unittest plumber.tests.test_plumber
+    ./py2/bin/python -m plumber.tests.__init__
 fi
 if [ -x "$(which python3)" ]; then
-    ./py3/bin/python -m unittest plumber.tests.test_plumber
+    ./py3/bin/python -m plumber.tests.__init__
 fi
 if [ -x "$(which pypy)" ]; then
-    ./pypy/bin/python -m unittest plumber.tests.test_plumber
+    ./pypy/bin/python -m plumber.tests.__init__
 fi

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development',
     ],
     keywords='',

--- a/src/plumber/behavior.py
+++ b/src/plumber/behavior.py
@@ -46,6 +46,8 @@ class behaviormetaclass(type):
 
     .. code-block:: pycon
 
+        >>> from plumber.behavior import Behavior
+        >>> from plumber.behavior import behaviormetaclass
         >>> from plumber.compat import add_metaclass
 
         >>> @add_metaclass(behaviormetaclass)
@@ -61,6 +63,7 @@ class behaviormetaclass(type):
 
         >>> getattr(A, '__plumbing_instructions__', None) and 'Behavior'
         'Behavior'
+
     """
 
     def __init__(cls, name, bases, dct):

--- a/src/plumber/instructions.py
+++ b/src/plumber/instructions.py
@@ -19,9 +19,15 @@ def payload(item):
 
     .. code-block:: pycon
 
-        >>> class Foo: pass
+        >>> from plumber.instructions import Instruction
+        >>> from plumber.instructions import payload
+
+        >>> class Foo:
+        ...     pass
+
         >>> payload(Instruction(Instruction(Foo))) is Foo
         True
+
     """
     if not isinstance(item, Instruction):
         return item
@@ -35,6 +41,8 @@ def plumb_str(leftdoc, rightdoc):
     and followed by an empty line.
 
     .. code-block:: pycon
+
+        >>> from plumber.instructions import plumb_str
 
         >>> leftdoc = '''Left head
         ...
@@ -50,7 +58,7 @@ def plumb_str(leftdoc, rightdoc):
         ... Right tail
         ... '''
 
-        >>> print plumb_str(leftdoc, rightdoc)
+        >>> print(plumb_str(leftdoc, rightdoc))
         Left head
         <BLANKLINE>
         Right head
@@ -69,9 +77,11 @@ def plumb_str(leftdoc, rightdoc):
 
         >>> leftdoc = '''Left tail
         ... '''
+
         >>> rightdoc = '''Right tail
         ... '''
-        >>> print plumb_str(leftdoc, rightdoc)
+
+        >>> print(plumb_str(leftdoc, rightdoc))
         Right tail
         <BLANKLINE>
         Left tail
@@ -80,10 +90,13 @@ def plumb_str(leftdoc, rightdoc):
         >>> class A: pass
         >>> plumb_str(A, None) is A
         True
+
         >>> plumb_str(None, A) is A
         True
+
         >>> plumb_str(None, None) is None
         True
+
     """
     if leftdoc is None:
         return rightdoc
@@ -110,13 +123,18 @@ class Instruction(object):
 
         .. code-block:: pycon
 
-            >>> class Foo: pass
+            >>> class Foo:
+            ...     pass
+
             >>> Instruction(Foo).item is Foo
             True
+
             >>> Instruction(Foo).__name__ is None
             True
+
             >>> Instruction(Foo, name='foo').__name__ == 'foo'
             True
+
         """
         self.item = item
         if name is not None:
@@ -131,6 +149,7 @@ class Instruction(object):
             Traceback (most recent call last):
               ...
             NotImplementedError
+
         """
         raise NotImplementedError
 
@@ -214,18 +233,24 @@ class default(Stage1Instruction):
 
         .. code-block:: pycon
 
+            >>> from plumber.instructions import default
+
             >>> def1 = default(1)
             >>> def1 + def1 is def1
             True
+
             >>> def2 = default(2)
             >>> def1 + def2 is def1
             True
+
             >>> def2 + def1 is def2
             True
 
         Override wins over default.
 
         .. code-block:: pycon
+
+            >>> from plumber.instructions import override
 
             >>> ext3 = override(3)
             >>> def1 + ext3 is ext3
@@ -234,6 +259,8 @@ class default(Stage1Instruction):
         Finalize wins over default.
 
         .. code-block:: pycon
+
+            >>> from plumber.instructions import finalize
 
             >>> fin4 = finalize(4)
             >>> def1 + fin4 is fin4
@@ -247,10 +274,11 @@ class default(Stage1Instruction):
             >>> def1 + Instruction('foo')
             Traceback (most recent call last):
               ...
-            PlumbingCollision:
+            plumber.exceptions.PlumbingCollision:
                 <default 'None' of None payload=1>
               with:
                 <Instruction 'None' of None payload='foo'>
+
         """
         if self == right:
             return self
@@ -290,12 +318,16 @@ class override(Stage1Instruction):
             >>> ext1 = override(1)
             >>> ext1 + ext1 is ext1
             True
+
             >>> ext1 + override(1) is ext1
             True
+
             >>> ext1 + override(2) is ext1
             True
+
             >>> ext1 + default(2) is ext1
             True
+
             >>> fin3 = finalize(3)
             >>> ext1 + fin3 is fin3
             True
@@ -307,10 +339,11 @@ class override(Stage1Instruction):
             >>> ext1 + Instruction(1)
             Traceback (most recent call last):
               ...
-            PlumbingCollision:
+            plumber.exceptions.PlumbingCollision:
                 <override 'None' of None payload=1>
               with:
                 <Instruction 'None' of None payload=1>
+
         """
         if self == right:
             return self
@@ -348,10 +381,13 @@ class finalize(Stage1Instruction):
             >>> fin1 = finalize(1)
             >>> fin1 + fin1 is fin1
             True
+
             >>> fin1 + finalize(1) is fin1
             True
+
             >>> fin1 + default(2) is fin1
             True
+
             >>> fin1 + override(2) is fin1
             True
 
@@ -362,7 +398,7 @@ class finalize(Stage1Instruction):
             >>> fin1 + finalize(2)
             Traceback (most recent call last):
               ...
-            PlumbingCollision:
+            plumber.exceptions.PlumbingCollision:
                 <finalize 'None' of None payload=1>
               with:
                 <finalize 'None' of None payload=2>
@@ -374,10 +410,11 @@ class finalize(Stage1Instruction):
             >>> fin1 + Instruction(1)
             Traceback (most recent call last):
               ...
-            PlumbingCollision:
+            plumber.exceptions.PlumbingCollision:
                 <finalize 'None' of None payload=1>
               with:
                 <Instruction 'None' of None payload=1>
+
         """
         if self == right:
             return self
@@ -446,6 +483,8 @@ class plumb(Stage2Instruction):
 
         .. code-block:: pycon
 
+            >>> from plumber import plumb
+
             >>> plb1 = plumb(1)
             >>> plb1 + plumb(1) is plb1
             True
@@ -453,7 +492,7 @@ class plumb(Stage2Instruction):
             >>> plb1 + Instruction(1)
             Traceback (most recent call last):
               ...
-            PlumbingCollision:
+            plumber.exceptions.PlumbingCollision:
                 <plumb 'None' of None payload=1>
               with:
                 <Instruction 'None' of None payload=1>
@@ -461,10 +500,11 @@ class plumb(Stage2Instruction):
             >>> plumb(lambda x: None) + plumb(property(lambda x: None))
             Traceback (most recent call last):
               ...
-            PlumbingCollision:
+            plumber.exceptions.PlumbingCollision:
                 <plumb 'None' of None payload=<function <lambda> at 0x...>>
               with:
                 <plumb 'None' of None payload=<property object at 0x...>>
+
         """
         if self == right:
             return self
@@ -483,10 +523,11 @@ class plumb(Stage2Instruction):
             >>> plumb(1) + plumb(2)
             Traceback (most recent call last):
               ...
-            PlumbingCollision:
+            plumber.exceptions.PlumbingCollision:
                 <plumb 'None' of None payload=1>
               with:
                 <plumb 'None' of None payload=2>
+
         """
         if isinstance(p1, STR_TYPE):
             return isinstance(p2, STR_TYPE) or p2 is None
@@ -516,7 +557,8 @@ class plumb(Stage2Instruction):
             return p1.__class__(*propfuncs)
         if callable(p1):
             return plbfunc(p1, p2)
-        raise RuntimeError("We should not reach this code!")  # pragma: no cover
+        # Should never happen
+        raise RuntimeError('Unknown plumbing case.')  # pragma: no cover
 
     def __call__(self, cls):
         # Check for a method on the plumbing class itself.
@@ -543,14 +585,18 @@ if ZOPE_INTERFACE_AVAILABLE:
 
         .. code-block:: pycon
 
+            >>> from plumber.instructions import _implements
+
             >>> foo = _implements(('foo',))
             >>> foo == foo
             True
+
             >>> foo + foo is foo
             True
 
             >>> foo == _implements(('foo',))
             True
+
             >>> foo != _implements(('bar',))
             True
 
@@ -567,15 +613,16 @@ if ZOPE_INTERFACE_AVAILABLE:
             >>> foo + bar == bar + foo
             True
 
-            >>> foo + Instruction("bar")
+            >>> foo + Instruction('bar')
             Traceback (most recent call last):
               ...
-            PlumbingCollision:
+            plumber.exceptions.PlumbingCollision:
                 <_implements '__interfaces__' of None payload=('foo',)>
               with:
                 <Instruction 'None' of None payload='bar'>
+
         """
-        __name__ = "__interfaces__"
+        __name__ = '__interfaces__'
 
         def __add__(self, right):
             if self == right:

--- a/src/plumber/instructions.py
+++ b/src/plumber/instructions.py
@@ -134,7 +134,7 @@ class Instruction(object):
         """
         raise NotImplementedError
 
-    def __call__(self, dct, bases=None):
+    def __call__(self, dct, derived_members=None):
         """Apply instruction to a plumbing, subclasses need to implement it.
 
         .. code-block:: pycon
@@ -144,8 +144,8 @@ class Instruction(object):
               ...
             NotImplementedError
 
-        ``bases`` is a wrapper for all base classes of the plumbing and
-        provides ``__contains__``, instructions may or may not need it.
+        ``derived_members`` is a set containing all base class members of the
+        plumbing, instructions may or may not need it.
         """
         raise NotImplementedError
 
@@ -262,9 +262,10 @@ class default(Stage1Instruction):
             return right
         raise PlumbingCollision(self, right)
 
-    def __call__(self, dct, bases):
-        if self.name not in dct and self.name not in bases:
-            dct[self.name] = self.payload
+    def __call__(self, dct, derived_members):
+        name = self.name
+        if name not in dct and name not in derived_members:
+            dct[name] = self.payload
 
 
 class override(Stage1Instruction):
@@ -321,7 +322,7 @@ class override(Stage1Instruction):
             return right
         raise PlumbingCollision(self, right)
 
-    def __call__(self, dct, bases):
+    def __call__(self, dct, derived_members):
         if self.name in dct:
             return
         dct[self.name] = self.payload
@@ -386,7 +387,7 @@ class finalize(Stage1Instruction):
             return self
         raise PlumbingCollision(self, right)
 
-    def __call__(self, dct, bases):
+    def __call__(self, dct, derived_members):
         if self.name in dct:
             raise PlumbingCollision('Plumbing class', self)
         dct[self.name] = self.payload

--- a/src/plumber/plumber.py
+++ b/src/plumber/plumber.py
@@ -3,7 +3,7 @@ from plumber.behavior import Instructions
 
 
 class Stacks(object):
-    """organize stacks for parsing behaviors, stored in the class' dict."""
+    """Organize stacks for parsing behaviors, stored in the class' dict."""
 
     attrname = '__plumbing_stacks__'
 
@@ -109,10 +109,9 @@ class plumber(type):
         cls = super(plumber, mcls).__new__(mcls, name, bases, dct)
 
         # install stage2
-        if '__plumbing__' in dct:
-            for stack in stacks.stage2.values():
-                instruction = stack[-1]
-                instruction(cls)
+        for stack in stacks.stage2.values():
+            instruction = stack[-1]
+            instruction(cls)
 
         return plumber.apply_metaclasshooks(cls, name, bases, dct)
 

--- a/src/plumber/plumber.py
+++ b/src/plumber/plumber.py
@@ -3,23 +3,16 @@ from plumber.behavior import Instructions
 
 
 class Stacks(object):
-    """Organize stacks for parsing behaviors, stored in the class' dict."""
+    """Organize stacks for parsing behaviors, stored in the class dict."""
 
     attrname = '__plumbing_stacks__'
 
     def __init__(self, dct):
-        self.dct = dct
-        self.dct.setdefault(self.attrname, dict())
-        self.stacks.setdefault('stages', dict())
-        self.stages.setdefault('stage1', dict())
-        self.stages.setdefault('stage2', dict())
-        self.stacks.setdefault('history', [])
-
-    stacks = property(lambda self: self.dct[self.attrname])
-    stages = property(lambda self: self.stacks['stages'])
-    stage1 = property(lambda self: self.stages['stage1'])
-    stage2 = property(lambda self: self.stages['stage2'])
-    history = property(lambda self: self.stacks['history'])
+        stacks = self.stacks = dct.setdefault(self.attrname, dict())
+        self.history = stacks.setdefault('history', [])
+        stages = self.stages = stacks.setdefault('stages', dict())
+        self.stage1 = stages.setdefault('stage1', dict())
+        self.stage2 = stages.setdefault('stage2', dict())
 
 
 def searchnameinbases(name, bases):
@@ -48,6 +41,7 @@ def searchnameinbases(name, bases):
 
 class Bases(object):
     """Used to search in base classes for attributes."""
+
     def __init__(self, bases):
         self.bases = bases
 
@@ -92,13 +86,12 @@ class plumber(type):
             for instruction in Instructions(behavior):
                 stage = stacks.stages[instruction.__stage__]
                 stack = stage.setdefault(instruction.__name__, [])
-                stacks.history.append(instruction)
-                if instruction not in stacks.history[:-1]:
+                # already seen instruction are ignored
+                if instruction not in stacks.history:
                     if stack:
                         instruction = stack[-1] + instruction
                     stack.append(instruction)
-                    continue
-                # already seen instruction is dropped
+                stacks.history.append(instruction)
 
         # install stage1
         for stack in stacks.stage1.values():

--- a/src/plumber/tests/__init__.py
+++ b/src/plumber/tests/__init__.py
@@ -1,1 +1,41 @@
-#
+from pprint import pprint
+import doctest
+import sys
+import unittest
+
+
+optionflags = (
+    doctest.NORMALIZE_WHITESPACE
+    | doctest.ELLIPSIS
+    | doctest.REPORT_ONLY_FIRST_FAILURE
+)
+
+
+if sys.version_info[0] >= 3:  # pragma: no cover
+    TESTFILES = [
+        '../../../README.rst',
+        '../behavior.py',
+        '../instructions.py'
+    ]
+else:  # pragma: no cover
+    TESTFILES = []
+
+
+def test_suite():
+    from plumber.tests import test_plumber
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.findTestCases(test_plumber))
+    suite.addTests([
+        doctest.DocFileSuite(
+            testfile,
+            globs=dict(pprint=pprint),
+            optionflags=optionflags
+        )
+        for testfile in TESTFILES
+    ])
+    return suite
+
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner()
+    runner.run(test_suite())

--- a/src/plumber/tests/globalmetaclass.py
+++ b/src/plumber/tests/globalmetaclass.py
@@ -22,6 +22,7 @@ class IBehavior1(Interface):
 
         >>> IBehavior1.__class__
         <class 'zope.interface.interface.InterfaceClass'>
+
     """
 
 
@@ -36,6 +37,7 @@ class Foo:
 
         >>> issubclass(Foo, object)
         True
+
     """
 
 
@@ -51,6 +53,7 @@ class ClassMaybeUsingAPlumbing(object):
 
         >>> ClassMaybeUsingAPlumbing.__class__
         <type 'type'>
+
     """
 
 
@@ -68,6 +71,7 @@ class ClassReallyUsingAPlumbing:
 
         >>> IBehavior1.implementedBy(ClassReallyUsingAPlumbing)
         True
+
     """
 
 
@@ -84,5 +88,6 @@ class BCClassReallyUsingAPlumbing:
 
         >>> IBehavior1.implementedBy(BCClassReallyUsingAPlumbing)
         True
+
     """
     __plumbing__ = Behavior1

--- a/src/plumber/tests/test_plumber.py
+++ b/src/plumber/tests/test_plumber.py
@@ -375,13 +375,11 @@ class TestPlumberBasics(unittest.TestCase):
         self.assertEqual(Sub().foobar(), 5)
 
         stacks = Plumbing.__plumbing_stacks__
-        self.assertEqual(len(stacks['history']), 5)
-        stages = stacks['stages']
-        self.assertEqual(sorted(list(stages.keys())), ['stage1', 'stage2'])
-        stage_1 = stages['stage1']
-        self.assertEqual(sorted(list(stage_1.keys())), ['a', 'bar', 'foo'])
-        stage_2 = stages['stage2']
-        self.assertEqual(sorted(list(stage_2.keys())), ['__interfaces__'])
+        self.assertEqual(len(stacks.history), 5)
+        stage1 = stacks.stage1
+        self.assertEqual(sorted(list(stage1.keys())), ['a', 'bar', 'foo'])
+        stage2 = stacks.stage2
+        self.assertEqual(sorted(list(stage2.keys())), ['__interfaces__'])
 
     @unittest.skipIf(
         sys.version_info[0] >= 3,

--- a/src/plumber/tests/test_plumber.py
+++ b/src/plumber/tests/test_plumber.py
@@ -79,14 +79,10 @@ class TestInstructions(unittest.TestCase):
         self.assertTrue(Instruction(Foo).item is Foo)
         self.assertTrue(Instruction(Foo).__name__ is None)
         self.assertTrue(Instruction(Foo, name='foo').__name__ == 'foo')
-        self.assertRaises(
-            NotImplementedError,
-            lambda: Instruction(None) + 1
-        )
-        self.assertRaises(
-            NotImplementedError,
-            lambda: Instruction(None)(None)
-        )
+        with self.assertRaises(NotImplementedError):
+            Instruction(None) + 1
+        with self.assertRaises(NotImplementedError):
+            Instruction(None)(None)
 
     def test_default(self):
         # First default wins from left to right
@@ -180,7 +176,8 @@ class TestInstructions(unittest.TestCase):
             self.assertEqual(err.right.__class__.__name__, 'Instruction')
             self.assertEqual(err.right.payload, 1)
         try:
-            func_a = lambda x: None
+            def func_a(x):
+                return None  # pragma: no cover
             prop_b = property(lambda x: None)
             plumb(func_a) + plumb(prop_b)
         except PlumbingCollision as e:
@@ -219,7 +216,7 @@ class TestInstructions(unittest.TestCase):
         self.assertTrue(foo + bar == bar + foo)
         err = None
         try:
-            foo + Instruction("bar")
+            foo + Instruction('bar')
         except PlumbingCollision as e:
             err = e
         finally:
@@ -328,7 +325,8 @@ class TestMetaclassHooks(unittest.TestCase):
         class Plumbing2(object):
             pass
 
-        self.assertRaises(AttributeError, lambda: Plumbing2.hooked)
+        with self.assertRaises(AttributeError):
+            Plumbing2.hooked
 
         plumber.__metaclass_hooks__.remove(test_metclass_hook)
 
@@ -413,7 +411,7 @@ class TestPlumberStage1(unittest.TestCase):
 
         res = list()
         for x in ['K', 'L', 'M', 'N']:
-            res.append("%s from %s" % (x, getattr(Plumbing, x)))
+            res.append('%s from %s' % (x, getattr(Plumbing, x)))
         self.assertEqual(res, [
             'K from Base',
             'L from Plumbing',
@@ -425,19 +423,19 @@ class TestPlumberStage1(unittest.TestCase):
         err = None
 
         class Behavior1(Behavior):
-            O = finalize(False)
+            O_ = finalize(False)
 
         try:
             @plumbing(Behavior1)
-            class Plumbing(object):
-                O = True
+            class Plumbing1(object):
+                O_ = True
         except PlumbingCollision as e:
             err = e
         finally:
             self.assertEqual(err.left, 'Plumbing class')
             self.assertEqual(err.right.__parent__.__name__, 'Behavior1')
             self.assertEqual(err.right.__class__.__name__, 'finalize')
-            self.assertEqual(err.right.__name__, 'O')
+            self.assertEqual(err.right.__name__, 'O_')
             self.assertFalse(err.right.payload)
 
         class Behavior2(Behavior):
@@ -445,7 +443,7 @@ class TestPlumberStage1(unittest.TestCase):
 
         try:
             @plumbing(Behavior2)
-            class Plumbing(object):
+            class Plumbing2(object):
                 P = True
         except PlumbingCollision as e:
             err = e
@@ -464,7 +462,7 @@ class TestPlumberStage1(unittest.TestCase):
 
         try:
             @plumbing(Behavior3, Behavior4)
-            class Plumbing(object):
+            class Plumbing3(object):
                 pass
         except PlumbingCollision as e:
             err = e
@@ -499,7 +497,7 @@ class TestPlumberStage1(unittest.TestCase):
 
         res = list()
         for x in ['K', 'L', 'M']:
-            res.append("%s from %s" % (x, getattr(Plumbing, x)))
+            res.append('%s from %s' % (x, getattr(Plumbing, x)))
         self.assertEqual(res, [
             'K from Plumbing',
             'L from Behavior2',
@@ -526,7 +524,7 @@ class TestPlumberStage1(unittest.TestCase):
 
         res = list()
         for x in ['K', 'L', 'M', 'N']:
-            res.append("%s from %s" % (x, getattr(Plumbing, x)))
+            res.append('%s from %s' % (x, getattr(Plumbing, x)))
         self.assertEqual(res, [
             'K from Base',
             'L from Plumbing',
@@ -553,7 +551,7 @@ class TestPlumberStage1(unittest.TestCase):
 
         res = list()
         for x in ['K', 'L']:
-            res.append("%s from %s" % (x, getattr(Plumbing, x)))
+            res.append('%s from %s' % (x, getattr(Plumbing, x)))
         self.assertEqual(res, [
             'K from Behavior2',
             'L from Behavior1'
@@ -578,7 +576,7 @@ class TestPlumberStage1(unittest.TestCase):
 
         res = list()
         for x in ['K', 'L']:
-            res.append("%s from %s" % (x, getattr(Plumbing, x)))
+            res.append('%s from %s' % (x, getattr(Plumbing, x)))
         self.assertEqual(res, [
             'K from Behavior2',
             'L from Behavior1'
@@ -603,7 +601,7 @@ class TestPlumberStage1(unittest.TestCase):
 
         res = list()
         for x in ['K', 'L']:
-            res.append("%s from %s" % (x, getattr(Plumbing, x)))
+            res.append('%s from %s' % (x, getattr(Plumbing, x)))
         self.assertEqual(res, [
             'K from Behavior2',
             'L from Behavior1'
@@ -642,18 +640,18 @@ class TestPlumberStage2(unittest.TestCase):
         class Behavior1(Behavior):
             @plumb
             def __getitem__(_next, self, key):
-                res.append("Behavior1 start")
+                res.append('Behavior1 start')
                 key = key.lower()
                 ret = _next(self, key)
-                res.append("Behavior1 stop")
+                res.append('Behavior1 stop')
                 return ret
 
         class Behavior2(Behavior):
             @plumb
             def __getitem__(_next, self, key):
-                res.append("Behavior2 start")
+                res.append('Behavior2 start')
                 ret = 2 * _next(self, key)
-                res.append("Behavior2 stop")
+                res.append('Behavior2 stop')
                 return ret
 
         Base = dict
@@ -740,7 +738,7 @@ class TestPlumberStage2(unittest.TestCase):
             foo = plumb(property(
                 None,
                 override(set_foo),
-                ))
+            ))
 
         @plumbing(Behavior2, Behavior3)
         class Plumbing2(object):
@@ -816,20 +814,20 @@ class TestPlumberStage2(unittest.TestCase):
             def foo(self):
                 """P1.foo
                 """
-            bar = plumb(property(None, None, None, "P1.bar"))
+            bar = plumb(property(None, None, None, 'P1.bar'))
 
         class P2(Behavior):
             @override
             def foo(self):
                 """P2.foo
                 """
-            bar = plumb(property(None, None, None, "P2.bar"))
+            bar = plumb(property(None, None, None, 'P2.bar'))
 
         @plumbing(P1, P2)
         class Plumbing(object):
             """Plumbing
             """
-            bar = property(None, None, None, "Plumbing.bar")
+            bar = property(None, None, None, 'Plumbing.bar')
 
         self.assertEqual(Plumbing.__doc__.strip(), 'Plumbing\n\nP1')
         self.assertEqual(Plumbing.foo.__doc__.strip(), 'P2.foo\n\nP1.foo')

--- a/src/plumber/tests/test_plumber.py
+++ b/src/plumber/tests/test_plumber.py
@@ -13,7 +13,6 @@ from plumber.instructions import Instruction
 from plumber.instructions import _implements
 from plumber.instructions import payload
 from plumber.instructions import plumb_str
-from plumber.plumber import searchnameinbases
 from zope.interface import Interface
 from zope.interface import implementer
 from zope.interface.interface import InterfaceClass
@@ -255,15 +254,15 @@ class TestBehavior(unittest.TestCase):
 
 class TestPlumber(unittest.TestCase):
 
-    def test_searchnameinbases(self):
+    def test_derived_members(self):
         class A(object):
             foo = 1
 
         class B(A):
             pass
 
-        self.assertTrue(searchnameinbases('foo', (B,)))
-        self.assertFalse(searchnameinbases('bar', (B,)))
+        self.assertTrue('foo' in plumber.derived_members((B,)))
+        self.assertFalse('bar' in plumber.derived_members((B,)))
 
 
 class TestGlobalMetaclass(unittest.TestCase):


### PR DESCRIPTION
- Replace ``Bases`` wrapper with a ``set`` containing ``derived_members``
  to avoid multiple base class iteration.

- Only keep most recent instructions on ``Stacks`` when parsing behaviors.

- Simplify ``Stacks`` object.

- Apply stage 1 and stage 2 instructions in ``plumber.__new__`` instead of
  applying stage 2 instructions in ``plumber.__init__``.